### PR TITLE
Make bin/openpgp more useful

### DIFF
--- a/bin/openpgp
+++ b/bin/openpgp
@@ -1,3 +1,48 @@
-#!/usr/bin/env ruby -rubygems
+#!/usr/bin/env ruby
+
+require 'rubygems'
+
 $:.unshift(File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib')))
 require 'openpgp'
+require 'optparse'
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: openpgp [options] FILE"
+
+  opts.on("-a", "--armor", "ASCII armor") do
+    options[:armor] = true
+  end
+
+  opts.on_tail("-h", "--help", "Show this message") do
+    puts opts
+    exit
+  end
+end.parse!
+
+
+input_file = ARGV.shift
+
+if input_file.nil?
+  puts "missing FILE"
+  exit
+end
+
+input = File.read(input_file)
+
+if options[:armor]
+  input = OpenPGP.dearmor(input)
+end
+
+msg = OpenPGP::Message.parse(input)
+
+puts "message:"
+msg.each do |packet|
+  puts "  #{packet.class.name} size=#{packet.size rescue '?'}"
+  case packet.class.name
+  when "OpenPGP::Packet"
+    puts "    ?"
+  else
+    puts "    #{packet.to_s}"
+  end
+end

--- a/lib/openpgp/packet.rb
+++ b/lib/openpgp/packet.rb
@@ -223,6 +223,11 @@ module OpenPGP
         buffer.write_byte(algorithm.to_i)
         buffer.write_s2k(s2k)
       end
+
+      def to_s
+        salt = s2k.salt.unpack('H*')
+        ":symkey enc packet: version #{version}, cipher #{algorithm}, hash #{s2k.algorithm}, salt #{salt}, count #{s2k.count}"
+      end
     end
 
     ##
@@ -348,6 +353,10 @@ module OpenPGP
 
       def write_body(buffer)
         buffer.write(data)
+      end
+
+      def to_s
+        ":encrypted data packet:"
       end
     end
 

--- a/lib/openpgp/s2k.rb
+++ b/lib/openpgp/s2k.rb
@@ -185,7 +185,7 @@ module OpenPGP
       end
 
       # @return [Integer]
-      attr_reader :count
+      attr_accessor :count
 
       ##
       # @param  [String, #to_s]          passphrase
@@ -221,16 +221,16 @@ module OpenPGP
         end
       end
 
+      ##
+      # @param  [Integer] count
+      # @return [Integer]
+      def decode_count(count)
+        (16 + (count & 15)) << ((count >> 4) + EXPBIAS)
+      end
+
       protected
 
         EXPBIAS = 6
-
-        ##
-        # @param  [Integer] count
-        # @return [Integer]
-        def decode_count(count)
-          (16 + (count & 15)) << ((count >> 4) + EXPBIAS)
-        end
 
         ##
         # @param  [Integer] iterations


### PR DESCRIPTION
I've added code to make it dump packets instead of doing nothing.

Regarding

```
#!/usr/bin/env ruby -rubygems
```

unfortunately, on some systems (e.g. Ubuntu Lucid), #! only splits the first two arguments, so the script fails to run.

Regarding decode_count - it's called here in a way which requires it to be public:

```
  s2k.count = s2k.decode_count(input.read_byte)
```

(ruby 1.8.7)
