### PR TITLE
Hash#index is deprecated in Ruby 1.9+

### DIFF
--- a/lib/openpgp/packet.rb
+++ b/lib/openpgp/packet.rb
@@ -21,7 +21,7 @@ module OpenPGP
     #
     # @return [Integer]
     def self.tag
-      @@tags.index(self)
+      @@tags.key(self)
     end
 
     ##


### PR DESCRIPTION
This resolves issue #5
